### PR TITLE
ci: add Django 6.0 and Python 3.14 to test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12', '3.13']
-        django-version: ['5.2', 'dev']
+        python-version: ['3.12', '3.13', '3.14']
+        django-version: ['5.2', '6.0', 'dev']
         database-engine: ["mysql", "postgres"]
 
     services:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,16 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Django",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.12,<3.15"
 dependencies = [
     "edc-csf>=1.3.0",
     "edc-microbiology>=1.3.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{312,313}-dj{52,dev},
+    py{312,313,314}-dj{52,60,dev},
     lint
     pre-commit
 
@@ -10,15 +10,18 @@ isolated_build = true
 python =
     3.12: py312, lint, pre-commit
     3.13: py313
+    3.14: py314
 
 [gh-actions:env]
 DJANGO =
     5.2: dj52
+    6.0: dj60
     dev: djdev, lint, pre-commit
 
 [testenv]
 deps =
     dj52: Django>=5.2,<5.3
+    dj60: Django>=6.0,<6.1
     djdev: git+https://github.com/django/django.git@main
 
 commands =


### PR DESCRIPTION
## Summary

- Extend CI matrix to cover **Django 6.0** and **Python 3.14** alongside 5.2 / 3.12 / 3.13
- Add `dj60: Django>=6.0,<6.1` dep for the new tox env
- Widen `requires-python` to `<3.15`
- Add `Framework :: Django :: 6.0` and `Python :: 3.14` classifiers

## Test plan
- [ ] Confirm all 18 matrix legs (3 Python × 3 Django × 2 DB) resolve and install
- [ ] Confirm Django 6.0 + Python 3.14 leg runs tests to completion
- [ ] Confirm Django 5.2 leg still passes (regression check)
- [ ] Confirm \`djdev\` leg installs and runs (early-warning channel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)